### PR TITLE
feat: Remove quiet option and disable debug by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function createEnv<
     const output = config({
       path: options.path,
       encoding: options.encoding,
-      debug: options.quiet ? false : undefined,
+      debug: false,
       processEnv: {},
     });
     rawEnv = output.parsed || {};

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -113,18 +113,6 @@ export interface CreateEnvOptions<
   encoding?: string;
 
   /**
-   * Suppresses all output from the underlying `dotenv` package, except for errors.
-   * This option is only relevant when loading from `.env` files.
-   *
-   * @default `false`
-   * @example
-   * ```typescript
-   * createEnv({ quiet: true, schema: mySchema, shared: [] });
-   * ```
-   */
-  quiet?: boolean;
-
-  /**
    * The Standard Schema compliant schema for validating environment variables.
    */
   schema: TSchema;


### PR DESCRIPTION
Removed the quiet option from CreateEnvOptions as it's no longer needed. Disabled debug mode by default in createEnv.