### PR TITLE
fix: Suppress dotenv advertisements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ export const venv = createEnv({
   shared: ['NODE_ENV', 'PORT', 'SHARED_SECRET'],
   // Optional dotenv options:
   // path: ['.env.local', '.env'],
-  // quiet: true,
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export function createEnv<
       path: options.path,
       encoding: options.encoding,
       debug: false,
+      quiet: true, // Suppress dotenv advertisements
       processEnv: {},
     });
     rawEnv = output.parsed || {};


### PR DESCRIPTION
Added `quiet: true` to the dotenv configuration to prevent unwanted advertisement messages from being logged to the console.